### PR TITLE
🚀 ci: add auth settings to static web app config

### DIFF
--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,4 +1,26 @@
 {
+  "auth": {
+    "identityProviders": {
+      "customOpenIdConnectProviders": {
+        "aadb2c": {
+          "registration": {
+            "clientIdSettingName": "AADB2C_PROVIDER_CLIENT_ID",
+            "clientCredential": {
+              "clientSecretSettingName": "AADB2C_PROVIDER_CLIENT_SECRET"
+            },
+            "openIdConnectConfiguration": {
+              "wellKnownOpenIdConfiguration": "https://aireadi.b2clogin.com/aireadi.onmicrosoft.com/B2C_1_userauth/v2.0/.well-known/openid-configuration"
+            }
+          },
+          "login": {
+            "nameClaimType": "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name",
+            "scopes": [],
+            "loginParameterNames": []
+          }
+        }
+      }
+    }
+  },
   "platform": {
     "apiRuntime": "node:18"
   },


### PR DESCRIPTION
Add initial configuration for Azure AD B2C tenant to static web app config.