### PR TITLE
🐛 fix: add scopes to get user details with login

### DIFF
--- a/pages/login.vue
+++ b/pages/login.vue
@@ -1,8 +1,12 @@
 <script setup lang="ts">
 const { accounts, inProgress, instance } = useMsal();
 
-const signupRedirect = () => {
-  instance.loginRedirect();
+const loginRedirect = () => {
+  instance.loginRedirect({ scopes: ["openid", "email", "profile"] });
+};
+
+const logout = () => {
+  instance.logoutRedirect();
 };
 </script>
 
@@ -13,8 +17,27 @@ const signupRedirect = () => {
 
       <VueJsonPretty :data="accounts" />
 
-      <div>
-        <n-button secondary type="info" @click="signupRedirect">
+      <div v-if="accounts.length">
+        <n-descriptions
+          v-for="account in accounts"
+          :key="account.localAccountId"
+          label-placement="top"
+          :title="account.localAccountId"
+        >
+          <n-descriptions-item label="Username">
+            {{ account.idTokenClaims.preferred_username }}
+          </n-descriptions-item>
+
+          <n-descriptions-item label="Email">
+            {{ account.idTokenClaims.email }}
+          </n-descriptions-item>
+        </n-descriptions>
+
+        <n-button secondary type="info" @click="logout">Log Out</n-button>
+      </div>
+
+      <div v-else>
+        <n-button secondary type="info" @click="loginRedirect">
           Sign Up and Sign In
         </n-button>
       </div>


### PR DESCRIPTION
Add missing scopes to get user details in the login response.