### PR TITLE
fix: minor updates to language for download

### DIFF
--- a/components/download/LicenseForm.vue
+++ b/components/download/LicenseForm.vue
@@ -38,7 +38,7 @@ onMounted(() => {
 
 <template>
   <div>
-    <n-form-item label="Review the license below.">
+    <n-form-item label="Please review the entire license below. Once you have reviewed the it you will be able to accept the license.">
       <n-input
         ref="textareaRef"
         type="textarea"

--- a/pages/datasets/[datasetid]/access/index.vue
+++ b/pages/datasets/[datasetid]/access/index.vue
@@ -96,7 +96,7 @@ const currentStep = ref<number>(1);
               <li>Log in using our authentication provider</li>
 
               <li>
-                Describe the purpose of your research. <br />
+                Describe the purpose of your research <br />
                 This information, along with your name, will be publicly shared
                 on the AI-READI website
               </li>

--- a/pages/datasets/[datasetid]/access/index.vue
+++ b/pages/datasets/[datasetid]/access/index.vue
@@ -95,7 +95,11 @@ const currentStep = ref<number>(1);
 
               <li>Log in using our authentication provider</li>
 
-              <li>Describe the purpose of your research</li>
+              <li>
+                Describe the purpose of your research. <br />
+                This information, along with your name, will be publicly shared
+                on the AI-READI website
+              </li>
 
               <li>Agree to the terms of the dataset license</li>
 

--- a/pages/datasets/[datasetid]/access/login.vue
+++ b/pages/datasets/[datasetid]/access/login.vue
@@ -27,7 +27,7 @@ const generateCombinedFullName = (name: string) => {
   }
 };
 
-const currentStep = ref<number>(2);
+const currentStep = ref<number>(3);
 
 const handleLogin = async () => {
   const redirectTo = route.fullPath;

--- a/pages/datasets/[datasetid]/access/research-purpose.vue
+++ b/pages/datasets/[datasetid]/access/research-purpose.vue
@@ -96,6 +96,12 @@ const validResearchPurpose = computed(
           <div>
             <h4>About Your Research</h4>
 
+            <p>
+              Please note, that by requesting a dataset, your name and research
+              purpose will be shared on the AI-READI website in order to promote
+              transparency and trust with the use of this data.
+            </p>
+
             <n-form-item label="Briefly describe the purpose of your research.">
               <n-input
                 v-model:value="researchPurpose"

--- a/pages/datasets/[datasetid]/access/submitted.vue
+++ b/pages/datasets/[datasetid]/access/submitted.vue
@@ -101,6 +101,11 @@ const currentStep = ref<number>(7);
             <p>
               Once created, you will have 72 hours to download your dataset.
             </p>
+
+            <p>
+              For those attending the Bridge2AI Open House in person, please
+              contact your DGP coordinator for details on accessing the dataset.
+            </p>
           </div>
         </TransitionFade>
       </div>

--- a/pages/datasets/[datasetid]/access/training.vue
+++ b/pages/datasets/[datasetid]/access/training.vue
@@ -26,7 +26,7 @@ const generateCombinedFullName = (name: string) => {
   }
 };
 
-const currentStep = ref<number>(3);
+const currentStep = ref<number>(2);
 const allAgreed = ref<boolean | null>(null);
 </script>
 


### PR DESCRIPTION
A few minor tweaks to the text to enhance clarify and provide more context.

## Discussion

I noticed one issue with the layout that I was uncertain how to call out regarding the steps. Specifically, the order is mixed up in the steps when on the training page. It shows that you are at the log in step 3 instead of the training step 2.

<img width="557" alt="ai-readi-download-step-2" src="https://github.com/AI-READI/fairhub-portal/assets/229781/1a5fa248-89c8-4b1f-9a45-e0b6c04ef469">
