### PR TITLE
🐛 fix: correct server-side auth redirect

### DIFF
--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -1,9 +1,13 @@
 export default defineNuxtRouteMiddleware((to) => {
   const { authenticated } = useUserDetails();
+  const config = useRuntimeConfig();
+
   if (!authenticated.value) {
     return navigateTo(
-      `${window.location.origin}/login-redirect?redirectTo=${to.fullPath}`,
-      { external: true },
+      `${config.public.BASE_URL}/login-redirect?redirectTo=${to.fullPath}`,
+      {
+        external: true,
+      },
     );
   }
 });

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -101,7 +101,7 @@ export default defineNuxtConfig({
       AIREADI_STUDY_UUID: "0ef3f72c-1bf0-4ea1-b9d1-e727c02b0f6c",
       BASE_URL:
         process.env.NUXT_SITE_ENV === "dev"
-          ? "http://localhost:6000"
+          ? "http://localhost:3000"
           : process.env.NUXT_SITE_ENV === "staging"
             ? "https://staging.fairhub.io"
             : "https://fairhub.io",


### PR DESCRIPTION
Use runtime configuration to construct the login redirect URL instead of `window.location`, which isn't available server-side. Fixes #116.