### PR TITLE
Orcid GitHub microsoft idp detection

### DIFF
--- a/components/download/LicenseForm.vue
+++ b/components/download/LicenseForm.vue
@@ -38,7 +38,7 @@ onMounted(() => {
 
 <template>
   <div>
-    <n-form-item label="Please review the entire license below. Once you have reviewed the it you will be able to accept the license.">
+    <n-form-item label="Please review the entire license below. Once you have reviewed it you will be able to accept the license.">
       <n-input
         ref="textareaRef"
         type="textarea"

--- a/pages/datasets/[datasetid]/access/login.vue
+++ b/pages/datasets/[datasetid]/access/login.vue
@@ -124,18 +124,17 @@ const handleLogin = async () => {
             <div v-else>
               <n-alert title="Please note:" type="info">
                 <p>
-                  On the next screen, you will have the ability to create an
-                  account for access (click on "Sign up now").
+                  On the next screen, you will authenticate for access via
+                  CILogon, a federated Identity Provider. You may use your
+                  institutional account by selecting your home institution from
+                  the drop-down list.
                 </p>
 
                 <p>
-                  When registering for access
-                  <strong
-                    >you must use your organization or institutional email
-                    address</strong
-                  >. Accounts not affiliated with a recognized entity email will
-                  be delayed and Al-READI admins will confirm your identity
-                  before granting access to the dataset.
+                  If you do not see your institution in the list of
+                  participating Identity Providers please contact the
+                  <a href="mailto:aireadi-dac@ohsu.edu">Data Access Committee</a
+                  >.
                 </p>
               </n-alert>
 

--- a/pages/forbiddenlogin.vue
+++ b/pages/forbiddenlogin.vue
@@ -6,45 +6,86 @@ const badIdPType = route.query.type;
 
 <template>
   <main class="flex h-full w-full flex-col items-center px-12 py-12">
-    <div class="font-dark text-5xl font-bold">403: Forbidden</div>
-
-    <p class="text-2xl font-light leading-normal md:text-3xl">
-      Thank you for your request.
-    </p>
-
-    <div v-if="badIdPType === 'adversarial'">
-      <p class="text-2xl font-light leading-normal md:text-3xl">
-        You have been directed to this page because you have authenticated using
-        an Identity Provider that is based in a country that has been designated
-        a country of concern by the US Government. At this time, we are awaiting
-        clarification from the Department of Justice on the recent executive
-        order on data sharing with countries of concern (<a
-          href="https://www.whitehouse.gov/briefing-room/presidential-actions/2024/02/28/executive-order-on-preventing-access-to-americans-bulk-sensitive-personal-data-and-united-states-government-related-data-by-countries-of-concern/"
-          >Details Here</a
-        >). Please know that we are fully committed to maximizing the impact of
-        the the data from our participants and data sharing but have been
-        advised to for clarification.
-      </p>
+    <div
+      class="font-dark justify-center bg-gradient-to-r from-sky-400 to-emerald-400 bg-clip-text text-5xl font-extrabold text-transparent"
+    >
+      403: Forbidden
     </div>
 
-    <div v-else>
-      <p class="text-2xl font-light leading-normal md:text-3xl">
-        The Identity Provider you have utilized has not been verified by the
-        Data Access committee to provide sufficiently secure user attestation.
+    <div class="flex flex-col items-center">
+      <p class="text-center text-2xl font-light leading-normal md:text-3xl">
+        Thank you for your request.
       </p>
-    </div>
 
-    <p class="md:text-3xl">
-      If you believe you were directed here mistakenly, please contact the
-      <a href="mailto:aireadi-dac@ohsu.edu">Data Access Committee</a>.
-    </p>
-
-    <a href="/">
-      <button
-        class="focus:shadow-outline-blue inline rounded-lg border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium leading-5 text-white shadow transition-colors duration-150 hover:bg-blue-700 focus:outline-none active:bg-blue-600"
+      <div
+        v-if="badIdPType === 'adversarial'"
+        class="container mx-auto justify-center"
       >
-        back to homepage
-      </button>
-    </a>
+        <p class="text-center text-2xl font-light leading-normal md:text-3xl">
+          You have been directed to this page because you have authenticated
+          using an Identity Provider that is based in a country that has been
+          designated a country of concern by the US Government. At this time, we
+          are awaiting clarification from the Department of Justice on the
+          recent executive order on data sharing with countries of concern (<a
+            href="https://www.whitehouse.gov/briefing-room/presidential-actions/2024/02/28/executive-order-on-preventing-access-to-americans-bulk-sensitive-personal-data-and-united-states-government-related-data-by-countries-of-concern/"
+            >Details Here</a
+          >). Please know that we are fully committed to maximizing the impact
+          of the the data from our participants and data sharing but have been
+          advised to for clarification.
+        </p>
+      </div>
+
+      <div v-else class="flex flex-col items-center">
+        <div>
+          <p class="text-center text-2xl font-light leading-normal md:text-3xl">
+            The Identity Provider you selected has not been verified by the
+            AI-READI Data Access committee to provide sufficient user
+            identification. If you authenticated using one of the following
+            accounts:
+          </p>
+        </div>
+
+        <div>
+          <ul
+            class="list justify-center text-2xl font-light leading-normal md:text-3xl"
+          >
+            <li>ORCID</li>
+
+            <li>GitHub</li>
+
+            <li>Google</li>
+
+            <li>Amazon AWS</li>
+          </ul>
+        </div>
+
+        <p class="text-center text-2xl font-light leading-normal md:text-3xl">
+          You can re-attempt using a valid account from an academic instution or
+          an eduGain-affiliated Identity Provider.
+        </p>
+      </div>
+
+      <p class="text-center md:text-3xl">
+        If you believe you were directed here mistakenly, please contact the
+        <a href="mailto:aireadi-dac@ohsu.edu">Data Access Committee</a>.
+      </p>
+
+      <br />
+
+      <a href="/">
+        <button
+          class="focus:shadow-outline-blue inline rounded-lg border border-transparent bg-blue-600 px-4 py-2 text-xl font-medium leading-5 text-white shadow transition-colors duration-150 hover:bg-blue-700 focus:outline-none active:bg-blue-600"
+        >
+          back to homepage
+        </button>
+      </a>
+    </div>
   </main>
 </template>
+
+<!-- <style scoped>
+.invalid-idp {
+  list-style: circle;
+  font-size: inherit;
+}
+</style> -->

--- a/pages/forbiddenlogin.vue
+++ b/pages/forbiddenlogin.vue
@@ -6,86 +6,72 @@ const badIdPType = route.query.type;
 
 <template>
   <main class="flex h-full w-full flex-col items-center px-12 py-12">
-    <div
-      class="font-dark justify-center bg-gradient-to-r from-sky-400 to-emerald-400 bg-clip-text text-5xl font-extrabold text-transparent"
-    >
-      403: Forbidden
-    </div>
+    <div class="font-dark text-5xl font-bold">403</div>
 
-    <div class="flex flex-col items-center">
+    <div class="items-left justify-left container mx-auto flex flex-col px-12">
       <p class="text-center text-2xl font-light leading-normal md:text-3xl">
         Thank you for your request.
       </p>
 
       <div
         v-if="badIdPType === 'adversarial'"
-        class="container mx-auto justify-center"
+        class="justify-left container mx-auto px-12"
       >
-        <p class="text-center text-2xl font-light leading-normal md:text-3xl">
+        <p class="text-left font-light leading-normal">
           You have been directed to this page because you have authenticated
           using an Identity Provider that is based in a country that has been
           designated a country of concern by the US Government. At this time, we
           are awaiting clarification from the Department of Justice on the
-          recent <a
+          recent
+          <a
             href="https://www.whitehouse.gov/briefing-room/presidential-actions/2024/02/28/executive-order-on-preventing-access-to-americans-bulk-sensitive-personal-data-and-united-states-government-related-data-by-countries-of-concern/"
             >executive order on data sharing with countries of concern</a
-          >. Please know that we are fully committed to maximizing the impact
-          of the the data from our participants and data sharing but have been
+          >. Please know that we are fully committed to maximizing the impact of
+          the the data from our participants and data sharing but have been
           advised to for clarification.
         </p>
       </div>
 
-      <div v-else class="flex flex-col items-center">
-        <div>
-          <p class="text-center text-2xl font-light leading-normal md:text-3xl">
-            The Identity Provider you selected has not been verified by the
-            AI-READI Data Access committee to provide sufficient user
-            identification. If you authenticated using one of the following
-            accounts:
-          </p>
-        </div>
+      <div v-else class="justify-left container mx-auto px-12">
+        <p class="justify-left text-left font-light leading-normal">
+          The Identity Provider you selected has not been verified by the
+          AI-READI Data Access committee to provide sufficient user
+          identification. If you authenticated using one of the following
+          accounts:
+        </p>
 
-        <div>
-          <ul
-            class="list justify-center text-2xl font-light leading-normal md:text-3xl"
-          >
-            <li>ORCID</li>
+        <ul
+          class="list justify-left list-inside text-left font-light leading-normal"
+        >
+          <li>ORCID</li>
 
-            <li>GitHub</li>
+          <li>GitHub</li>
 
-            <li>Google</li>
+          <li>Google</li>
 
-            <li>Amazon AWS</li>
-          </ul>
-        </div>
+          <li>Amazon AWS</li>
+        </ul>
 
-        <p class="text-center text-2xl font-light leading-normal md:text-3xl">
+        <p class="text-left font-light leading-normal">
           You can re-attempt using a valid account from an academic instution or
           an eduGain-affiliated Identity Provider.
         </p>
       </div>
 
-      <p class="text-center md:text-3xl">
+      <p class="mb-8 px-12 text-left">
         If you believe you were directed here mistakenly, please contact the
-        <a href="mailto:aireadi-dac@ohsu.edu">Data Access Committee</a>.
+        <a href="mailto:aireadi-dac@ohsu.edu" class="underline"
+          >Data Access Committee</a
+        >.
       </p>
-
-      <br />
-
-      <a href="/">
-        <button
-          class="focus:shadow-outline-blue inline rounded-lg border border-transparent bg-blue-600 px-4 py-2 text-xl font-medium leading-5 text-white shadow transition-colors duration-150 hover:bg-blue-700 focus:outline-none active:bg-blue-600"
-        >
-          back to homepage
-        </button>
-      </a>
     </div>
+
+    <a href="/">
+      <button
+        class="focus:shadow-outline-blue inline rounded-lg border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium leading-5 text-white shadow transition-colors duration-150 hover:bg-blue-700 focus:outline-none active:bg-blue-600"
+      >
+        back to homepage
+      </button>
+    </a>
   </main>
 </template>
-
-<!-- <style scoped>
-.invalid-idp {
-  list-style: circle;
-  font-size: inherit;
-}
-</style> -->

--- a/pages/forbiddenlogin.vue
+++ b/pages/forbiddenlogin.vue
@@ -26,10 +26,10 @@ const badIdPType = route.query.type;
           using an Identity Provider that is based in a country that has been
           designated a country of concern by the US Government. At this time, we
           are awaiting clarification from the Department of Justice on the
-          recent executive order on data sharing with countries of concern (<a
+          recent <a
             href="https://www.whitehouse.gov/briefing-room/presidential-actions/2024/02/28/executive-order-on-preventing-access-to-americans-bulk-sensitive-personal-data-and-united-states-government-related-data-by-countries-of-concern/"
-            >Details Here</a
-          >). Please know that we are fully committed to maximizing the impact
+            >executive order on data sharing with countries of concern</a
+          >. Please know that we are fully committed to maximizing the impact
           of the the data from our participants and data sharing but have been
           advised to for clarification.
         </p>

--- a/server/routes/login.get.ts
+++ b/server/routes/login.get.ts
@@ -117,7 +117,17 @@ function checkTokenIdPIsValid(tokenResponse: AuthenticationResult): string {
     /(\.kp\/)/, // Democratic People's Republic of Korea
     /(\.ru\/)/, // Russian Federation
   ];
-  const selfAttestationIdPPatterns = [/(sts\.windows\.net)/, /github\.com/];
+  const selfAttestationIdPPatterns = [
+    /(sts\.windows\.net)/,
+    /(github\.com)/,
+    /(orcid\.org)/,
+    /(microsoftonline\.com)/,
+    /(google\.com)/,
+    /(amazonaws\.com)/,
+    /(saml\.nelnet\.net)/,
+    /(miracosta\.fedgw\.com)/,
+    /(cirrusidentity)/,
+  ];
 
   const indexableClaims = { ...tokenResponse.idTokenClaims };
   const idpName = getStringTokenClaim(indexableClaims, "idp");


### PR DESCRIPTION
Certain identity providers only pass a VERY limited set of claims (specifically only openID, not any of the other useful claims) and this was breaking the user journey that allowed us to authenticate. fortunately this should not affect any of the SAML IdPs and provides us a sure-fire way to filter IdPs that allow user self-sign up without ID verification. I have made an update to the b2c custom policy to address this and added several regexes to the IdP check; additionally I made a few requested changes to the 403 forbidden landing page, fixed a known typo with the license text, and per Abby's request made a tentative update to the login instruction verbiage.