### PR TITLE
added email regex to email claim

### DIFF
--- a/server/routes/login.get.ts
+++ b/server/routes/login.get.ts
@@ -52,7 +52,8 @@ function getEmail(tokenResponse: AuthenticationResult): string {
     email = tokenResponse.account.username;
   } else if (
     "email" in tokenResponse.idTokenClaims &&
-    typeof tokenResponse.idTokenClaims.email === "string"
+    typeof tokenResponse.idTokenClaims.email === "string" &&
+    emailRegex.test(tokenResponse.idTokenClaims.email)
   ) {
     email = tokenResponse.idTokenClaims.email;
   } else if ("emails" in tokenResponse.idTokenClaims) {


### PR DESCRIPTION
previously a blank email claim would still evaluate to an email claim coming back; added regex check to verify that email claim value is valid