### PR TITLE
fix: persist agreement for every request

### DIFF
--- a/pages/datasets/[datasetid]/access/license.vue
+++ b/pages/datasets/[datasetid]/access/license.vue
@@ -94,7 +94,7 @@ const licenseAndAttestationComplete = computed(() => {
 
 const handleSubmit = async () => {
   try {
-    await $fetch(`/api/downloads/agreement/create`, {
+    const agreement = await $fetch(`/api/downloads/agreement/create`, {
       body: {
         attestation_accepted: attestationsAccepted.value,
         dataset_id: dataset.value?.id,
@@ -105,7 +105,7 @@ const handleSubmit = async () => {
       method: "POST",
     });
 
-    agreementFormState.value = {};
+    agreementFormState.value = agreement;
     await navigateTo(`/datasets/${dataset.value?.id}/access/select`);
   } catch (error) {
     console.error(error);

--- a/pages/datasets/[datasetid]/access/select.vue
+++ b/pages/datasets/[datasetid]/access/select.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import useDownloadAgreementForm from "~/composables/useDownloadAgreementForm";
+
 definePageMeta({
   middleware: ["auth"],
 });
@@ -7,7 +9,7 @@ const route = useRoute();
 
 const { datasetid } = route.params as { datasetid: string };
 const { data: dataset, error } = await useDataset(datasetid);
-const { data: agreement } = await useDownloadAgreement(datasetid);
+const agreement = useDownloadAgreementForm(datasetid);
 
 if (error.value) {
   console.error(error.value);
@@ -51,6 +53,8 @@ const handleSubmit = async () => {
       headers: useRequestHeaders(["cookie"]),
       method: "POST",
     });
+    // clear the agreement form once we have persisted the request
+    agreement.value = {};
     await navigateTo(`/datasets/${dataset.value?.id}/access/submitted`);
   } catch (error) {
     console.error(error);

--- a/server/api/downloads/agreement/create.post.ts
+++ b/server/api/downloads/agreement/create.post.ts
@@ -26,18 +26,6 @@ export default defineEventHandler(async (event) => {
     user_details_id: true,
   };
 
-  const existingAgreement = await prisma.download_agreement.findFirst({
-    select: selectProps,
-    where: {
-      dataset_id: postBody.dataset_id,
-      user_details_id: userDetails.id,
-    },
-  });
-
-  if (existingAgreement) {
-    return existingAgreement;
-  }
-
   try {
     const timestamp = currentUnixTimestamp();
     const agreement = await prisma.download_agreement.create({


### PR DESCRIPTION
Originally, we only expected a single agreement was required for requesting a dataset, but now that users can make requests for both diabetes and non-diabetes projects we need to ensure they have the appropriate agreement in place for any request.

This change persists the agreementForm cookie through the data set request step so that we can associate the newly created agreement with the new request.