### PR TITLE
fix: use populated dataset structure description for folder selection

### DIFF
--- a/pages/datasets/[datasetid]/access/select.vue
+++ b/pages/datasets/[datasetid]/access/select.vue
@@ -133,7 +133,6 @@ const handleSubmit = async () => {
 
             <DownloadFolderSelector
               v-model="selectedFolders"
-              :folder-structure="dataset?.files || []"
               :dataset-structure-description="
                 dataset?.metadata
                   .datasetStructureDescription as DatasetStructureDescription


### PR DESCRIPTION
The `files` attribute of the dataset json no longer appears to be populated. This happened with the last data release as well. This refactors the `DownloadFolderSelector` component to use the `datasetStructureDescription` construct which contains all the required elements.